### PR TITLE
Add experimental support for HTML templates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2457,6 +2457,47 @@ function defineCustomElement(tag) {
 	return registerElement(tag, validatedOptions);
 }
 
+var Template = function () {
+	function Template(selector) {
+		var scope = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : document.body;
+		classCallCheck(this, Template);
+
+		this.template = scope.querySelector('template' + selector);
+	}
+
+	createClass(Template, [{
+		key: 'render',
+		value: function render() {
+			var values = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+			var fragment = this.template.content.cloneNode(true);
+
+			Object.entries(values).forEach(function (_ref) {
+				var _ref2 = slicedToArray(_ref, 2),
+				    selector = _ref2[0],
+				    value = _ref2[1];
+
+				try {
+					var part = fragment.querySelector(selector);
+
+					if (part) {
+						if (typeof value === 'string') {
+							part.textContent = value;
+						} else if ((typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object' && !Array.isArray(value)) {
+							Object.assign(part, value);
+						}
+					}
+				} catch (e) {
+					console.warn('Invalid template replacement for selector `' + selector + '`');
+				}
+			});
+
+			return fragment;
+		}
+	}]);
+	return Template;
+}();
+
 // Base Controller
 
 exports.BaseController = BaseController;
@@ -2475,3 +2516,4 @@ exports.parseHTML = parseHTML;
 exports.renderNodes = renderNodes;
 exports.cleanNodes = cleanNodes;
 exports.promisify = promisify;
+exports.Template = Template;

--- a/src/index.js
+++ b/src/index.js
@@ -18,3 +18,4 @@ export { default as defineCustomElement } from './util/define';
 export { parse as parseEvent, getPath as getEventPath } from './util/events';
 export { parseHTML, renderNodes, cleanNodes } from './util/html';
 export { default as promisify } from './util/promise';
+export { default as Template } from './util/template';

--- a/src/util/template.js
+++ b/src/util/template.js
@@ -1,0 +1,27 @@
+export default class Template {
+	constructor(selector, scope = document.body) {
+		this.template = scope.querySelector(`template${selector}`);
+	}
+
+	render(values = {}) {
+		const fragment = this.template.content.cloneNode(true);
+
+		Object.entries(values).forEach(([selector, value]) => {
+			try {
+				const part = fragment.querySelector(selector);
+
+				if (part) {
+					if (typeof value === 'string') {
+						part.textContent = value;
+					} else if (typeof value === 'object' && !Array.isArray(value)) {
+						Object.assign(part, value);
+					}
+				}
+			} catch (e) {
+				console.warn(`Invalid template replacement for selector \`${selector}\``);
+			}
+		});
+
+		return fragment;
+	}
+}


### PR DESCRIPTION
**HTML**

```html
<template id="tpl-user-profile>
  <mr-user-profile class="user-profile>
    <img class="user-profile__image" />
    <span class="user-profile__name"></span>
  </mr-user-profile>
</template>
```


**Javascript**

```es6
const tpl = new Template('user-profile');

tpl.render({
  '.user-profile__image': {
    src: 'foo.jpg'
  },
  '.user-profile__name': 'Yves'
});```