### PR TITLE
Support JSONP custom callback key

### DIFF
--- a/src/elements/ajax-form.js
+++ b/src/elements/ajax-form.js
@@ -3,7 +3,7 @@ import fetchJSONP from '../util/fetch';
 
 const ajaxForm = {
 	attributes: [
-		{ attribute: 'jsonp', type: 'bool' },
+		{ attribute: 'jsonp', type: 'string' },
 	],
 	controller: class extends BaseController {
 		get action() {
@@ -15,7 +15,7 @@ const ajaxForm = {
 		}
 
 		get method() {
-			if (this.jsonp) {
+			if (typeof this.jsonp !== 'undefined') {
 				return 'GET';
 			}
 
@@ -117,8 +117,8 @@ const ajaxForm = {
 		}
 
 		submit(url, params = {}) {
-			if (this.jsonp) {
-				return fetchJSONP(url);
+			if (typeof this.jsonp !== 'undefined') {
+				return fetchJSONP(url, this.jsonp === '' ? undefined : this.jsonp);
 			}
 
 			return fetch(url, params).then((res) => {

--- a/src/internal/attribute-methods-generator.js
+++ b/src/internal/attribute-methods-generator.js
@@ -2,7 +2,11 @@ const noop = function () {};
 
 const generateStringAttributeMethods = function (attribute) {
 	const getter = function () {
-		return this.el.getAttribute(attribute) || undefined;
+		if (this.el.hasAttribute(attribute)) {
+			return this.el.getAttribute(attribute);
+		}
+
+		return undefined;
 	};
 
 	const setter = function (to) {

--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -31,7 +31,7 @@ const parseResponse = function (res) {
 	return { status, data };
 };
 
-const fetchJSONP = function (url) {
+const fetchJSONP = function (url, paramKey = 'callback') {
 	return new Promise((resolve, reject) => {
 		// Register a global callback
 		// Make sure we have a unique function name
@@ -59,7 +59,7 @@ const fetchJSONP = function (url) {
 
 		const script = document.createElement('script');
 		script.id = callback;
-		script.src = `${url}&callback=${callback}`;
+		script.src = `${url}&${paramKey}=${callback}`;
 		document.head.appendChild(script);
 	});
 };


### PR DESCRIPTION
At the moment, having an AJAX form element run in JSONP-mode always adds `callback=` to the form action.

When using it with Mailchimp, this has to be `c=` for the form to work properly.

In this PR, I make the key configurable by using the `jsonp` attribute as a string attribute. I made sure the default `jsonp` keeps working to avoid breaking stuff 😉 

## Usage

```html
<ajax-form action="https://example.com/foo" jsonp>
```

Will do a JSONP GET to `https://example.com/foo?callback=AJAX_FORM_CALLBACK_GENERATED` just like in the current stable version.

```html
<ajax-form action="https://example.com/foo" jsonp="c">
```

Will do a JSONP GET to `https://example.com/foo?c=AJAX_FORM_CALLBACK_GENERATED` just like in the current stable version.
