### PR TITLE
waitForDOMReady: is not correctly implemented

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,20 +58,24 @@ function promisify(method) {
 }
 
 function waitForDOMReady() {
-	return new Promise(function (resolve) {
-		if (document.readyState === 'complete') {
-			resolve();
-		} else {
-			var handler = function handler() {
-				if (document.readyState === 'complete') {
-					document.removeEventListener('readystatechange', handler, false);
-					resolve();
-				}
-			};
+  return new Promise(function (resolve) {
+    if (isInteractive()) {
+      resolve();
+    } else {
+      var handler = function handler() {
+        if (isInteractive()) {
+          document.removeEventListener("readystatechange", handler, false);
+          resolve();
+        }
+      };
 
-			document.addEventListener('readystatechange', handler, false);
-		}
-	});
+      document.addEventListener("readystatechange", handler, false);
+    }
+  });
+}
+
+function isInteractive() {
+  return document.readyState === "complete" || document.readyState === "interactive";
 }
 
 function elementIsInDOM(element) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrhenry/custom-elements-helpers",
-  "version": "2.5.8",
+  "version": "2.6.0",
   "description": "A collection of Custom Elements v1 helpers",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrhenry/custom-elements-helpers",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "A collection of Custom Elements v1 helpers",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/src/util/dom-ready.js
+++ b/src/util/dom-ready.js
@@ -1,16 +1,22 @@
 export default function waitForDOMReady() {
-	return new Promise((resolve) => {
-		if (document.readyState === 'complete') {
-			resolve();
-		} else {
-			const handler = function () {
-				if (document.readyState === 'complete') {
-					document.removeEventListener('readystatechange', handler, false);
-					resolve();
-				}
-			};
+  return new Promise(resolve => {
+    if (isInteractive()) {
+      resolve();
+    } else {
+      const handler = function() {
+        if (isInteractive()) {
+          document.removeEventListener("readystatechange", handler, false);
+          resolve();
+        }
+      };
 
-			document.addEventListener('readystatechange', handler, false);
-		}
-	});
+      document.addEventListener("readystatechange", handler, false);
+    }
+  });
+}
+
+function isInteractive() {
+  return (
+    document.readyState === "complete" || document.readyState === "interactive"
+  );
 }


### PR DESCRIPTION
The _`DOMReady` event (interactive)_  refers to when the entire **DOM** of the document is loaded. Previously the `waitForDOMReady()` handler waited for the _`onload` event (complete)_. This function will now wait until the document is _`interactive`_ or _`complete`_. On many sites this cuts **hundreds of milliseconds** on the time to _visual completion_.